### PR TITLE
Increased timeout of initial status check

### DIFF
--- a/WiimoteGun/WiimoteLib/Wiimote.cs
+++ b/WiimoteGun/WiimoteLib/Wiimote.cs
@@ -76,7 +76,7 @@ namespace WiimoteLib {
 				}
 
 				// force a status check to get the state of any extensions plugged in at startup
-				GetStatus(500);
+				GetStatus(3000);
 			}
 			catch {
 				Dispose();


### PR DESCRIPTION
Extending the initial timeout time was required to get my TR Wiimote to work with WiimoteGun. Without that, WiimoteGun would just keep erroring out after the timeout was reached. Just for reference, I use a Dolphinbar to connect my TR Wiimote to my PC.